### PR TITLE
bugfix: Fix hierarchy_strings_to_alias ordering

### DIFF
--- a/stratumus/stratumus.py
+++ b/stratumus/stratumus.py
@@ -63,7 +63,7 @@ class Stratum(object):
     def walk_configs(self):
         for hierarchy in self.hierarchies:
             glob_pattern_to_join = [self.config_dir]
-            hierarchy_strings_to_alias = {}
+            hierarchy_strings_to_alias = OrderedDict()
             for i, h in enumerate(hierarchy):
                 if isinstance(h, str):
                     hierarchy_string = h


### PR DESCRIPTION
hierarchy_strings_to_alias needs to be ordered so zip to hierarchy_dict respect the orginal hierarchy