### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,24 +23,24 @@ Given this directory structure:
     data
     ├── config
     │   └── dev
-    │       ├── foo
-    │       │   ├── api.yaml
-    │       │   └── api
-    │       │       ├── us-east-1
-    │       │       │   └── external.yaml
-    │       │       └── us-west-2
-    │       │           └── external.yaml
-    │       ├── prod
-    │       │   └── api
-    │       │       └── us-east-1
-    │       │           ├── external.yaml
-    │       │           └── internal.yaml
-    │       ├── @
-    │       │   └── api.yaml
-    │       └── @
-    │           └── @
-    │               └── @
-    │                   └── external.yaml
+    │   |   ├── foo
+    │   |       ├── api.yaml
+    │   |       └── api
+    │   |           ├── us-east-1
+    │   |           │   └── external.yaml
+    │   |           └── us-west-2
+    │   |               └── external.yaml
+    │   └── prod
+    │   |   └── api
+    │   |       └── us-east-1
+    │   |           ├── external.yaml
+    │   |           └── internal.yaml
+    │   ├── @
+    │   │   └── api.yaml
+    │   └── @
+    │       └── @
+    │           └── @
+    │               └── external.yaml
     └── default
         ├── app
         │   ├── api.yaml


### PR DESCRIPTION
If the hierarchy is `env namespace app region group` then prod and dev are both a `env` according to the examples in filtering. In the tree, `prod` is inside of `config/data/dev` instead of in `config/data/`.